### PR TITLE
SB-331: Add a maven invoker test case for missing artifacts

### DIFF
--- a/src/it/resolve-non-existent-artifact/invoker.properties
+++ b/src/it/resolve-non-existent-artifact/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean compile -e

--- a/src/it/resolve-non-existent-artifact/pom.xml
+++ b/src/it/resolve-non-existent-artifact/pom.xml
@@ -1,0 +1,21 @@
+<project>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.carlspring.maven</groupId>
+    <artifactId>test-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+    </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>snapshots-with-invalid-user</id>
+            <name>snapshots-with-invalid-user</name>
+            <url>http://@strongbox.host@:@port.jetty.listen@/storages/storage0/snapshots/</url>
+            <uniqueVersion>true</uniqueVersion>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/src/it/resolve-non-existent-artifact/src/main/java/org/carlspring/strongbox/test/HelloWorld.java
+++ b/src/it/resolve-non-existent-artifact/src/main/java/org/carlspring/strongbox/test/HelloWorld.java
@@ -1,0 +1,11 @@
+package org.carlspring.strongbox.test;
+
+public class HelloWorld
+{
+    
+    public static void main(String[] args)
+    {
+        System.out.println("Hello, world!");
+    }
+    
+}

--- a/src/it/resolve-non-existent-artifact/verify.groovy
+++ b/src/it/resolve-non-existent-artifact/verify.groovy
@@ -1,0 +1,23 @@
+import org.carlspring.strongbox.client.ArtifactClient
+
+
+def client = ArtifactClient.getTestInstance()
+
+System.out.println()
+System.out.println()
+System.out.println(client.getHost())
+System.out.println(client.getUsername())
+System.out.println(client.getPassword())
+System.out.println()
+System.out.println()
+
+def response = client.pathExists("/storages/storage0/snapshots/org/carlspring/strongbox/test/non-existent/" +
+                                 "1.0-SNAPSHOT/non-existent-1.0-SNAPSHOT.jar")
+
+System.out.println()
+System.out.println()
+System.out.println("Path exists? " + response.toString())
+System.out.println()
+System.out.println()
+
+return !response


### PR DESCRIPTION
Implemented.

Note: This can't be done at a POM-level because the settings.xml file for the Maven invoker tests is pointing to the local file system and, for the sake of quicker testing, it's not actually hitting a remote repository for resolving artifacts, (it's only hitting it when deploying them).