### PR TITLE
Upgrade gradle to version 5.3

### DIFF
--- a/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip

--- a/gradle/src/it/common-flow/build.gradle
+++ b/gradle/src/it/common-flow/build.gradle
@@ -36,7 +36,6 @@ uploadArchives {
             pom.groupId = "org.carlspring.strongbox.examples"
             pom.artifactId = "hello-strongbox-gradle"
             pom.version = "1.0-SNAPSHOT"
-            uniqueVersion = false
     }
 }
 

--- a/gradle/src/it/common-flow/settings.gradle
+++ b/gradle/src/it/common-flow/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'common-flow'

--- a/gradle/src/it/common-flow/test-gradle-common-flow.groovy
+++ b/gradle/src/it/common-flow/test-gradle-common-flow.groovy
@@ -31,8 +31,13 @@ runCommand(executionPath, String.format("$gradleExec upload -Dcredentials.userna
                                         password))
 
 // check if artifact was uploaded to Strongbox
+def artifactFilenames = new FileNameByRegexFinder()
+                        .getFileNames(project.build.directory +
+                                      '/strongbox-vault/storages/storage0/snapshots/org/carlspring/strongbox/' +
+                                      'examples/hello-strongbox-gradle/1.0-SNAPSHOT', 'hello-strongbox-gradle-1.0-\\d{8}\\.\\d{6}-\\d\\.jar$')
+assert artifactFilenames.size() == 1
 assert targetPath.resolve('strongbox-vault/storages/storage0/snapshots/org/carlspring/strongbox/' +
                           'examples/hello-strongbox-gradle/1.0-SNAPSHOT')
-                 .resolve('hello-strongbox-gradle-1.0-SNAPSHOT.jar')
+                 .resolve(artifactFilenames[0])
                  .toFile().exists()
 


### PR DESCRIPTION
Fixes issue strongbox/strongbox#1150.

Does the following:

- Upgrades Gradle to 5.3.
- Gradle 5.3 chokes without a `settings.gradle` file for the `common-flow` module.
- The option to disable date/time-stamping artifacts went away in version 3 of Maven, or at least the MavenDeployer used by Gradle 5.2 and above.  Refactored assertion in test to look for a date/time-stamped JAR file