### PR TITLE
Issue-1322 Drop maven commons (strongbox/strongbox#1322)

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>
@@ -309,12 +304,6 @@
                                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                                 <artifactId>jackson-jaxrs-json-provider</artifactId>
                                 <version>${version.jackson}</version>
-                            </dependency>
-
-                            <dependency>
-                                <groupId>org.carlspring.maven</groupId>
-                                <artifactId>maven-commons</artifactId>
-                                <version>${version.carlspring.maven.commons}</version>
                             </dependency>
 
                             <dependency>

--- a/maven/src/it/deploy-and-delete/pom.xml
+++ b/maven/src/it/deploy-and-delete/pom.xml
@@ -14,12 +14,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/deploy-large-file/pom.xml
+++ b/maven/src/it/deploy-large-file/pom.xml
@@ -14,12 +14,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/deploy-snapshot-to-release-repository/pom.xml
+++ b/maven/src/it/deploy-snapshot-to-release-repository/pom.xml
@@ -14,12 +14,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/deploy-with-invalid-user/pom.xml
+++ b/maven/src/it/deploy-with-invalid-user/pom.xml
@@ -13,12 +13,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/deploy-with-valid-user/pom.xml
+++ b/maven/src/it/deploy-with-valid-user/pom.xml
@@ -13,12 +13,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/redeploy-release-artifact-allowed/pom.xml
+++ b/maven/src/it/redeploy-release-artifact-allowed/pom.xml
@@ -15,12 +15,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/maven/src/it/redeploy-release-artifact-forbidden/pom.xml
+++ b/maven/src/it/redeploy-release-artifact-forbidden/pom.xml
@@ -14,12 +14,6 @@
             <artifactId>strongbox-client</artifactId>
             <version>@project.version@</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-            <version>@version.carlspring.maven.commons@</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/npm/pom.xml
+++ b/npm/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>

--- a/nuget/pom.xml
+++ b/nuget/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>

--- a/sbt/pom.xml
+++ b/sbt/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.carlspring.maven</groupId>
-            <artifactId>maven-commons</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
         </dependency>


### PR DESCRIPTION
This PR removes `maven-commons` from the dependencies.
Although this PR fails, it works as expected when tested in strongbox/strongbox#1324 (it here fails because 1324 needs to be merged into the master).