### PR TITLE
Fix for unexpected strongbox instance shutdown.

### DIFF
--- a/strongbox-web-integration-tests-parent/pom.xml
+++ b/strongbox-web-integration-tests-parent/pom.xml
@@ -287,6 +287,9 @@
                               -Dlogging.debug=${logging.debug}
                               -Dlogging.console.enabled=${logging.console.enabled}
                               -Dlogging.file.enabled=${logging.file.enabled}
+                              -Dstrongbox.nuget.download.feed=false
+                              -Dstrongbox.download.indexes=false
+                              -Dstrongbox.npm.remote.changes.enabled=false
                             </jvmArguments>
                         </configuration>
 


### PR DESCRIPTION
Remote indexes download cron jobs disabled for all protocols.