### PR TITLE
Issue-1397: Set strongbox-parent version to 1.0-PR-39-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-PR-39-SNAPSHOT</version>
     </parent>
 
     <artifactId>strongbox-web-integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-PR-39-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>strongbox-web-integration-tests</artifactId>

--- a/strongbox-web-integration-tests-parent/pom.xml
+++ b/strongbox-web-integration-tests-parent/pom.xml
@@ -6,11 +6,12 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-PR-39-SNAPSHOT</version>
         <relativePath />
     </parent>
 
     <artifactId>strongbox-web-integration-tests-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Web Integration Tests [Parent]</name>
@@ -58,6 +59,7 @@
             <artifactId>strongbox-jetty-booter</artifactId>
             <version>${project.version}</version>
         </dependency>
+
     </dependencies>
 
     <profiles>

--- a/strongbox-web-integration-tests-parent/pom.xml
+++ b/strongbox-web-integration-tests-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-PR-39-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Related to strongbox/strongbox#1397.

## Tasks
- [x] Set `strongbox-parent` version to `1.0-PR-39-SNAPSHOT`, so that it takes new versions from `commons-io` and `commons-http`.