### PR TITLE
Issue 1827: Update integration tests to use Gradle 6.6.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
                                 tools = 'mvn mono choco'
                             },
                             gradle: {
-                                agent = 'alpine-jdk8-mvn3.6-gradle5.6'
+                                agent = 'alpine-jdk8-mvn3.6-gradle6.6'
                                 tools = 'mvn gradle'
                             },
                             maven: {},

--- a/gradle/docker-compose.yml
+++ b/gradle/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   strongbox-web-integration-tests-gradle:
-    image: strongboxci/alpine:jdk8-mvn3.6-gradle5.6
+    image: strongboxci/alpine:jdk8-mvn3.6-gradle6.6
     volumes:
       - $HOME/.m2/repository:/home/jenkins/.m2/repository
       - ../:/workspace

--- a/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1827

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
  
# Code Review And Pre-Merge Checklist

* [ ] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.

