### PR TITLE
Issue-1905: Remove version on Nuget-related env variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,31 +117,40 @@ pipeline {
                             choco: {
                                 agent = 'alpine-jdk8-mvn3.6-mono5-nuget3.4-choco0.10'
                                 tools = 'mvn mono choco'
+                                mavenArgs = '-U'
                             },
                             gradle: {
                                 agent = 'alpine-jdk8-mvn3.6-gradle6.6'
                                 tools = 'mvn gradle'
+                                mavenArgs = '-U'
                             },
-                            maven: {},
+                            maven: {
+                                mavenArgs = '-U'
+                            },
                             npm: {
                                 agent = 'alpine-jdk8-mvn3.6-node12'
                                 tools = 'mvn npm node yarn'
+                                mavenArgs = '-U'
                             },
                             nuget: {
                                 agent = 'alpine-jdk8-mvn3.6-mono5-nuget3.4'
                                 tools = 'mvn mono'
+                                mavenArgs = '-U'
                             },
                             sbt: {
                                 agent = 'alpine-jdk8-mvn3.6-sbt1.3'
                                 tools = 'mvn'
+                                mavenArgs = '-U'
                             },
                             pypi: {
                                 agent = 'alpine-jdk8-mvn3.6-pip19.3'
                                 tools = 'mvn python pip'
+                                mavenArgs = '-U'
                             },
                             raw: {
                                 container = 'maven'
                                 tools = 'mvn'
+                                mavenArgs = '-U'
                             }
                         ]
                     }

--- a/nuget/src/it/test-install-with-transitive-deps.groovy
+++ b/nuget/src/it/test-install-with-transitive-deps.groovy
@@ -11,8 +11,8 @@ def targetPath = getTargetPath(project)
 def baseDir = targetPath.toString()
 def configPath = "$baseDir/NuGet.config"
 
-def nugetExec = System.getenv("NUGET_V3_EXEC")
-assert nugetExec?.trim() : "\"NUGET_V3_EXEC\" environment variable need to be set"
+def nugetExec = System.getenv("NUGET_EXEC")
+assert nugetExec?.trim() : "\"NUGET_EXEC\" environment variable need to be set"
 
 def packageExtension = "nupkg"
 

--- a/nuget/src/it/test-nuget-common-flow.groovy
+++ b/nuget/src/it/test-nuget-common-flow.groovy
@@ -11,8 +11,8 @@ def targetPath = getTargetPath(project)
 def baseDir = targetPath.toString()
 def configPath = "$baseDir/NuGet.config"
 
-def nugetExec = System.getenv("NUGET_V3_EXEC")
-assert nugetExec?.trim() : "\"NUGET_V3_EXEC\" environment variable need to be set"
+def nugetExec = System.getenv("NUGET_EXEC")
+assert nugetExec?.trim() : "\"NUGET_EXEC\" environment variable need to be set"
 
 def packageId = "Org.Carlspring.Strongbox.Examples.Nuget.Mono" 
 def packageVersion = "1.0.0"

--- a/nuget/src/it/test-prepare-nuget-config.groovy
+++ b/nuget/src/it/test-prepare-nuget-config.groovy
@@ -7,8 +7,8 @@ println "Test test-prepare-nuget-config.groovy" + "\n\n"
 
 def targetPath = getTargetPath(project)
 
-def nugetExec = System.getenv("NUGET_V3_EXEC")
-assert nugetExec?.trim() : "\"NUGET_V3_EXEC\" environment variable need to be set"
+def nugetExec = System.getenv("NUGET_EXEC")
+assert nugetExec?.trim() : "\"NUGET_EXEC\" environment variable need to be set"
 
 def nugetApiKey = getApiKey()
 


### PR DESCRIPTION
Necessary to allow for different major versions to be used without the
needing of code changes.

Refs #1905

# Pull Request Description

This pull request closes strongbox/strongbox#1905

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [x] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [x] Yes, please see strongbox/ci-build-images#21...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
  
# Code Review And Pre-Merge Checklist

* [ ] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [ ] New and existing unit tests pass locally with my changes.

