### PR TITLE
Issue 1910: Set strongbox-parent version to 1.0-issue-1910-dep-upgrade-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1910-dep-upgrade-SNAPSHOT</version>
     </parent>
 
     <artifactId>strongbox-web-integration-tests</artifactId>

--- a/strongbox-web-integration-tests-parent/pom.xml
+++ b/strongbox-web-integration-tests-parent/pom.xml
@@ -6,11 +6,12 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1910-dep-upgrade-SNAPSHOT</version>
         <relativePath />
     </parent>
 
     <artifactId>strongbox-web-integration-tests-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Web Integration Tests [Parent]</name>


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1910

## Tasks
- [x] Set `strongbox-parent` version to `1.0-issue-1910-dep-upgrade-SNAPSHOT`, so that it takes new versions from `Jersey` dependencies.

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No
  
# Code Review And Pre-Merge Checklist

* [ ] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [ ] New and existing unit tests pass locally with my changes.

